### PR TITLE
Fix authentication with aes

### DIFF
--- a/pre2k/lib/ldap.py
+++ b/pre2k/lib/ldap.py
@@ -113,7 +113,7 @@ def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='
     from impacket.krb5.types import Principal, KerberosTime, Ticket
     import datetime
 
-    if TGT is not None or TGS is not None:
+    if TGT is not None or TGS is not None or aesKey is not None:
         useCache = False
 
     if useCache:


### PR DESCRIPTION
Hello! 

I faced an error while using aes key for authentication, and this fix worked for me. Please let me know if that fixes the issue for you as well. 

Thanks!

Output before:
```
─$ /home/kali/.local/bin/pre2k auth -d essos.local -u daenerys.targaryen -aes cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -k -dc-ip 192.168.56.12 -verbose

                                ___    __         
                              /'___`\ /\ \        
 _____   _ __    __          /\_\ /\ \\ \ \/'\    
/\ '__`\/\`'__\/'__`\ _______\/_/// /__\ \ , <    
\ \ \L\ \ \ \//\  __//\______\  // /_\ \\ \ \\`\  
 \ \ ,__/\ \_\\ \____\/______/ /\______/ \ \_\ \_\
  \ \ \/  \/_/ \/____/         \/_____/   \/_/\/_/
   \ \_\                                      v3.0    
    \/_/                                          
                                            @garrfoster
                                            @Tw1sm          

[00:41:33] DEBUG    Using Kerberos Cache: None                                                                                                         
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/kali/.local/pipx/venvs/pre2k/lib/python3.11/site-packages/pre2k/lib/commands/auth.py:33 in │
│ main                                                                                             │
│                                                                                                  │
│   30 │   │   │   │   │   ldaps=ldaps, kerberos=kerberos, no_pass=no_pass, hashes=hashes, aes=    │
│   31 │   │   │   │   │   outputfile=outputfile, stop_on_success=stop_on_success, save=save,      │
│   32 │   │   │   │   │   empty_pass=empty_pass, sleep=sleep, jitter=jitter, threads=threads)     │
│ ❱ 33    pre2k.run()                                                                              │
│                                                                                                  │
│ /home/kali/.local/pipx/venvs/pre2k/lib/python3.11/site-packages/pre2k/lib/pre_2k.py:67 in run    │
│                                                                                                  │
│    64 │   │   │   │   │   self.password = getpass("Password:")                                   │
│    65 │   │   │                                                                                  │
│    66 │   │   │   try:                                                                           │
│ ❱  67 │   │   │   │   ldap_server, ldap_session = init_ldap_session(domain=self.domain, userna   │
│    68 │   │   │   except ldap3.core.exceptions.LDAPSocketOpenError as e:                         │
│    69 │   │   │   │   if 'invalid server address' in str(e):                                     │
│    70 │   │   │   │   │   logger.error (f'Invalid server address - {self.domain}')               │
│                                                                                                  │
│ /home/kali/.local/pipx/venvs/pre2k/lib/python3.11/site-packages/pre2k/lib/ldap.py:77 in          │
│ init_ldap_session                                                                                │
│                                                                                                  │
│    74 │   │   except ldap3.core.exceptions.LDAPSocketOpenError:                                  │
│    75 │   │   │   return init_ldap_connection(target, ssl.PROTOCOL_TLSv1, domain, username, pa   │
│    76 │   else:                                                                                  │
│ ❱  77 │   │   return init_ldap_connection(target, None, domain, username, password, lmhash, nt   │
│    78                                                                                            │
│    79 def ldap3_kerberos_login(connection, target, user, password, domain='', lmhash='', nthas   │
│    80 │   from pyasn1.codec.ber import encoder, decoder                                          │
│                                                                                                  │
│ /home/kali/.local/pipx/venvs/pre2k/lib/python3.11/site-packages/pre2k/lib/ldap.py:47 in          │
│ init_ldap_connection                                                                             │
│                                                                                                  │
│    44 │   if kerberos:                                                                           │
│    45 │   │   ldap_session = ldap3.Connection(ldap_server)                                       │
│    46 │   │   ldap_session.bind()                                                                │
│ ❱  47 │   │   ldap3_kerberos_login(ldap_session, target, username, password, domain, lmhash, n   │
│    48 │   elif hashes is not None:                                                               │
│    49 │   │   if lmhash == "":                                                                   │
│    50 │   │   │   lmhash = "aad3b435b51404eeaad3b435b51404ee"                                    │
│                                                                                                  │
│ /home/kali/.local/pipx/venvs/pre2k/lib/python3.11/site-packages/pre2k/lib/ldap.py:136 in         │
│ ldap3_kerberos_login                                                                             │
│                                                                                                  │
│   133 │   │   │   logger.debug('Using Kerberos Cache: %s' % os.getenv('KRB5CCNAME'))             │
│   134 │   │   │   principal = 'ldap/%s@%s' % (target.upper(), domain.upper())                    │
│   135 │   │   │                                                                                  │
│ ❱ 136 │   │   │   creds = ccache.getCredential(principal)                                        │
│   137 │   │   │   if creds is None:                                                              │
│   138 │   │   │   │   # Let's try for the TGT and go from there                                  │
│   139 │   │   │   │   principal = 'krbtgt/%s@%s' % (domain.upper(), domain.upper())              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'getCredential'
```

Output after:
```
└─$ /home/kali/.local/bin/pre2k auth -d essos.local -u daenerys.targaryen -aes cf091fbd07f729567ac448ba96c08b12fa67c1372f439ae093f67c6e2cf82378 -k -dc-ip 192.168.56.12 -verbose

                                ___    __         
                              /'___`\ /\ \        
 _____   _ __    __          /\_\ /\ \\ \ \/'\    
/\ '__`\/\`'__\/'__`\ _______\/_/// /__\ \ , <    
\ \ \L\ \ \ \//\  __//\______\  // /_\ \\ \ \\`\  
 \ \ ,__/\ \_\\ \____\/______/ /\______/ \ \_\ \_\
  \ \ \/  \/_/ \/____/         \/_____/   \/_/\/_/
   \ \_\                                      v3.0    
    \/_/                                          
                                            @garrfoster
                                            @Tw1sm          

[00:46:32] INFO     Retrieved 2 results total.                                                                                                         
[00:46:32] INFO     Testing started at 2023-06-30 00:46:32                                                                                             
[00:46:32] INFO     Using 10 threads                                                                                                                   
[00:46:32] DEBUG    Invalid credentials: essos.local\MEEREEN$:meereen                                                                                  
[00:46:32] DEBUG    Invalid credentials: essos.local\BRAAVOS$:braavos
```