### PR TITLE
fix: add err handling 4 when sAMAccountName is NoneType

### DIFF
--- a/pre2k/lib/machine_hunter.py
+++ b/pre2k/lib/machine_hunter.py
@@ -34,12 +34,16 @@ class MachineHunter:
                 json_entry = json.loads(entry.entry_to_json())
                 attributes = json_entry['attributes'].keys()
                 for attr in attributes:
-                    val = entry[attr].value
-                    if len(val) >= 15:
-                        #if account name is 15 chars or more pw is first 14
-                        credentials = val + ":" + val.lower()[:14]
-                    else:
-                        credentials = val + ":" + val.lower()[:-1]
-                    creds.append(credentials)
+                    try:
+                        val = entry[attr].value
+                        if len(val) >= 15:
+                            #if account name is 15 chars or more pw is first 14
+                            credentials = val + ":" + val.lower()[:14]
+                        else:
+                            credentials = val + ":" + val.lower()[:-1]
+                        creds.append(credentials)
+                    except TypeError as e:
+                        print(f"Error processing attribute {attr}: {e}")
+                        continue
             logger.info (f'Retrieved {len(self.ldap_session.entries)} results total.')
             return creds

--- a/pre2k/lib/pre_2k.py
+++ b/pre2k/lib/pre_2k.py
@@ -80,7 +80,7 @@ class Pre2k:
                 logger.error(f'Error: {str(e)}')
                 exit()
             finder=MachineHunter(ldap_server, ldap_session, domain=self.domain, targeted=self.targeted)
-            self. creds = finder.fetch_computers(ldap_session)
+            self.creds = finder.fetch_computers(ldap_session)
             self.pw_spray()
 
 


### PR DESCRIPTION
fix: add err handling 4 when sAMAccountName is NoneType

This resolves what would otherwise result in a crash and incomplete execution when an empty sAMAccountName is encountered

Also, removed an empty space in `self. creds` var name which seemed unintended.
![image](https://github.com/garrettfoster13/pre2k/assets/58376398/da3965a2-9e64-461b-aea3-9d72811849de)

With Patch:
![image](https://github.com/garrettfoster13/pre2k/assets/58376398/d270ec69-a88a-4c7d-8026-9bc8bf428b15)
