### PR TITLE
Changed targeted from logoncount=0 to use lastlogontimestamp

### DIFF
--- a/pre2k/lib/commands/auth.py
+++ b/pre2k/lib/commands/auth.py
@@ -18,7 +18,7 @@ def main(
     no_pass         : bool  = typer.Option(False, "-no-pass", help="don't ask for password (useful for -k)"),
     hashes          : str   = typer.Option(None, "-hashes",metavar="LMHASH:NTHASH", help="LM and NT hashes, format is LMHASH:NTHASH",),
     aes             : str   = typer.Option(None, '-aes', metavar="HEX KEY", help='AES key to use for Kerberos Authentication (128 or 256 bits)'),
-    targeted        : bool  = typer.Option(False, '-targeted', help="Search for computer accounts with logoncount=0."),
+    targeted        : bool  = typer.Option(False, '-targeted', help="Search for computer accounts with lastlogontimestamp not set"),
     verbose         : bool  = typer.Option(False, "-verbose", help="Verbose output displaying failed attempts."),
     outputfile      : str   = typer.Option(None, "-outputfile", help="Log results to file."),
     stop_on_success : bool  = typer.Option(False, "-stoponsuccess", help="Stop on sucessful authentication"),

--- a/pre2k/lib/machine_hunter.py
+++ b/pre2k/lib/machine_hunter.py
@@ -23,7 +23,7 @@ class MachineHunter:
         num = 0
         with console.status(f"Searching...", spinner="dots") as status:
             if self.targeted:
-                search_filter = "(&(objectclass=computer)(logonCount=0))"
+                search_filter = "(&(objectClass=computer)(!(lastLogonTimestamp=*)))"
             else:
                 search_filter = "(objectclass=computer)"
             try:


### PR DESCRIPTION
Since logoncount is not replicated between domain controllers you will experience various results using the -targeted option. IMO a better approach would be to use the lastlogontimestamp since this is replicated between domain controllers and will be empty for prestine pre2k accounts.

https://learn.microsoft.com/en-us/windows/win32/adschema/a-logoncount#remarks